### PR TITLE
Refactor get requests to return ok tuples

### DIFF
--- a/lib/auth/api.ex
+++ b/lib/auth/api.ex
@@ -8,6 +8,7 @@ defmodule Auth.Api do
     "Content-Type" => "application/x-www-form-urlencoded"
   })
 
+  plug(Tesla.Middleware.Tuples)
   plug(Tesla.Middleware.JSON)
   plug(Tesla.Middleware.Logger)
 
@@ -16,13 +17,19 @@ defmodule Auth.Api do
     |> parse_result()
   end
 
-  defp parse_result(result) do
+  defp parse_result({:ok, %Tesla.Env{body: body}}) do
     current_time = System.system_time(:second)
 
-    %Auth.Model.Token{
-      access_token: result.body["access_token"],
-      expires_at: current_time + result.body["expires_in"]
+    token = %Auth.Model.Token{
+      access_token: body["access_token"],
+      expires_at: current_time + body["expires_in"]
     }
+
+    {:ok, token}
+  end
+
+  defp parse_result({:error, error}) do
+    {:error, error}
   end
 
   defp encode_authorization_header() do

--- a/lib/auth/in_memory.ex
+++ b/lib/auth/in_memory.ex
@@ -2,9 +2,11 @@ defmodule Auth.InMemory do
   def get_token() do
     current_time = System.system_time(:second)
 
-    %Auth.Model.Token{
+    token = %Auth.Model.Token{
       access_token: "ACCESS_TOKEN_FROM_AUTH_API",
       expires_at: current_time + 3600
     }
+
+    {:ok, token}
   end
 end

--- a/lib/scenes/main.ex
+++ b/lib/scenes/main.ex
@@ -15,7 +15,7 @@ defmodule Restid.Scene.Main do
   def init(_, _) do
     graph =
       Graph.build(font_size: @font_size, font: @font)
-      |> text("Blipp", id: :content, translate: {0, 20})
+      |> text("Resor har inte kunnat laddas än", id: :content, translate: {0, 20})
 
     Sensor.subscribe(:trips)
 

--- a/lib/sensors/trips.ex
+++ b/lib/sensors/trips.ex
@@ -30,6 +30,8 @@ defmodule Restid.Sensor.Trips do
     trips =
       state.destinations
       |> Enum.map(&Restid.get_trips(state.origin, &1))
+      |> Enum.filter(&match?({:ok, _}, &1))
+      |> Enum.map(fn {:ok, trips} -> trips end)
       |> Enum.flat_map(&get_in(&1, ["TripList", "Trip"]))
 
     Sensor.publish(:trips, trips)


### PR DESCRIPTION
# What does this PR do?

Refactor get requests to use {:ok, result} convention to more easily manage errors.

# Why was this PR needed?

The app would crash when starting in nerves on a real device. Since the Tesla request were executed before the wifi was up and running and that resulted in Tesla throwing an error.
