### PR TITLE
Change graph colors to dark text on bright background

### DIFF
--- a/lib/scenes/main.ex
+++ b/lib/scenes/main.ex
@@ -3,6 +3,7 @@ defmodule Restid.Scene.Main do
   The main Scenic.Scene that shows a list of trips.
   """
   use Scenic.Scene
+
   alias Scenic.Graph
   alias Scenic.Sensor
 
@@ -12,10 +13,19 @@ defmodule Restid.Scene.Main do
   @font :roboto
   @font_size 20
 
-  def init(_, _) do
+  def init(_, opts) do
+    {:ok, %Scenic.ViewPort.Status{size: {width, height}}} =
+      opts[:viewport]
+      |> Scenic.ViewPort.info()
+
     graph =
-      Graph.build(font_size: @font_size, font: @font)
-      |> text("Resor har inte kunnat laddas än", id: :content, translate: {0, 20})
+      Graph.build(font_size: @font_size, font: @font, theme: :light)
+      |> rectangle({width, height}, fill: :white)
+      |> text("Resor har inte kunnat laddas än",
+        fill: :black,
+        id: :content,
+        translate: {0, 20}
+      )
 
     Sensor.subscribe(:trips)
 


### PR DESCRIPTION
# What does this PR do?

Tweak the graph colors so that they are dark text on bright background.

# Why was this PR needed?

It was difficult to read white text on dark background.

