### PR TITLE
Refactor response to a new data struct

### DIFF
--- a/config/env/dev.exs
+++ b/config/env/dev.exs
@@ -1,3 +1,4 @@
 use Mix.Config
 
 config :restid, :auth_api, Auth.Api
+config :restid, :restid_api, Restid.Api.Http

--- a/config/env/prod.exs
+++ b/config/env/prod.exs
@@ -1,3 +1,4 @@
 use Mix.Config
 
 config :restid, :auth_api, Auth.Api
+config :restid, :restid_api, Restid.Api.Http

--- a/config/env/test.exs
+++ b/config/env/test.exs
@@ -1,3 +1,4 @@
 use Mix.Config
 
 config :restid, :auth_api, Auth.InMemory
+config :restid, :restid_api, Restid.Api.InMemory

--- a/lib/auth.ex
+++ b/lib/auth.ex
@@ -21,7 +21,7 @@ defmodule Auth do
   ## Examples
 
     iex> Auth.get_token()
-    "ACCESS_TOKEN_FROM_AUTH_API"
+    {:ok, "ACCESS_TOKEN_FROM_AUTH_API"}
   """
   def get_token do
     GenServer.call(__MODULE__, :get_token)

--- a/lib/components/trip.ex
+++ b/lib/components/trip.ex
@@ -1,0 +1,90 @@
+defmodule Restid.Component.Trip do
+  use Scenic.Component
+  import Scenic.Primitives
+
+  alias Scenic.Graph
+  alias Scenic.ViewPort
+
+  @height 60
+
+  @graph Graph.build()
+         |> text("",
+           id: :departure_time,
+           text_align: :left_top,
+           fill: :black,
+           translate: {0, 0},
+           font_size: 50
+         )
+         |> text("Spårvagn 9",
+           id: :description,
+           text_align: :left_top,
+           fill: :black,
+           font_size: 20,
+           translate: {115, 5}
+         )
+         |> text("Framme kl XX:XX",
+           id: :arrival_time,
+           text_align: :left_top,
+           fill: :black,
+           font_size: 20,
+           translate: {115, 25}
+         )
+
+  def info(data),
+    do: """
+      #{IO.ANSI.red()}#{__MODULE__} data must be a bitstring
+      #{IO.ANSI.yellow()}Received: #{inspect(data)}
+      #{IO.ANSI.default_color()}
+    """
+
+  def verify(%Restid.Response.Trip{} = trip), do: {:ok, trip}
+  def verify(_), do: :invalid_data
+
+  def init(trip, opts) do
+    trip_as_string = "Test"
+
+    # modify the already built graph
+    graph =
+      @graph
+      |> Graph.modify(:_root_, &update_opts(&1, styles: opts[:styles]))
+      |> Graph.modify(:description, &text(&1, format_description(trip)))
+      |> Graph.modify(:departure_time, &text(&1, format_time(trip.expected_departure_date_time)))
+      |> Graph.modify(
+        :arrival_time,
+        &text(&1, "Framme kl #{format_time(trip.expected_arrival_date_time)}")
+      )
+
+    state = %{
+      graph: graph,
+      text: trip_as_string
+    }
+
+    {:ok, state, push: graph}
+  end
+
+  defp format_time({:real_time, date_time}) do
+    "#{pad(date_time.hour)}:#{pad(date_time.minute)}"
+  end
+
+  defp format_time({:scheduled, date_time}) do
+    "~#{pad(date_time.hour)}:#{pad(date_time.minute)}"
+  end
+
+  defp format_time(:unknown) do
+    "N/A"
+  end
+
+  defp format_time(%NaiveDateTime{} = date_time) do
+    "#{pad(date_time.hour)}:#{pad(date_time.minute)}"
+  end
+
+  defp pad(number) do
+    String.pad_leading("#{number}", 2, "0")
+  end
+
+  defp format_description(%Restid.Response.Trip{legs: legs}) do
+    legs
+    |> Enum.map(&Map.get(&1, :name))
+    |> Enum.join(", ")
+  end
+end

--- a/lib/restid.ex
+++ b/lib/restid.ex
@@ -22,7 +22,7 @@ defmodule Restid do
         {:error, error}
 
       {:ok, token} ->
-        trips =
+        response =
           client(token)
           |> Reseplaneraren.Api.Trip.get_trip(
             originCoordLat: origin.lat,
@@ -34,10 +34,9 @@ defmodule Restid do
             format: "json"
           )
           |> parse_results()
-          |> trim_leading_walk_directions()
-          |> trim_trailing_walk_directions()
+          |> Restid.Response.parse_from_json()
 
-        {:ok, trips}
+        {:ok, response}
     end
   end
 

--- a/lib/restid.ex
+++ b/lib/restid.ex
@@ -52,27 +52,4 @@ defmodule Restid do
   # for some reason all the api calls returns an error
   # but the value seems to be parsed properly
   defp parse_results({:error, %Poison.ParseError{value: json}}), do: json
-
-  defp trim_leading_walk_directions(trips_result) do
-    update_in(trips_result, ["TripList", "Trip"], fn trips ->
-      Enum.map(trips, fn trip ->
-        update_in(trip, ["Leg"], fn legs ->
-          Enum.drop_while(legs, fn leg -> leg["type"] === "WALK" end)
-        end)
-      end)
-    end)
-  end
-
-  defp trim_trailing_walk_directions(trips_result) do
-    update_in(trips_result, ["TripList", "Trip"], fn trips ->
-      Enum.map(trips, fn trip ->
-        update_in(trip, ["Leg"], fn legs ->
-          legs
-          |> Enum.reverse()
-          |> Enum.drop_while(fn leg -> leg["type"] === "WALK" end)
-          |> Enum.reverse()
-        end)
-      end)
-    end)
-  end
 end

--- a/lib/restid.ex
+++ b/lib/restid.ex
@@ -4,13 +4,14 @@ defmodule Restid do
   """
   use Tesla
 
-  alias Restid.Model.Location
+  alias Restid.Request.Location
 
   @doc """
   Returns the trips from a given `origin` to a given `destination`.
 
   ## Examples
 
+      iex> alias Restid.Request.Location
       iex> origin = %Location{name: "Seglaregatan", lat: 57.690368, long: 11.919743}
       iex> destination = %Location{name: "Centralstationen", lat: 57.708713, long: 11.973301}
       iex> Restid.get_trips(origin, destination)

--- a/lib/restid/api/http.ex
+++ b/lib/restid/api/http.ex
@@ -1,0 +1,41 @@
+defmodule Restid.Api.Http do
+  alias Restid.Request.Location
+
+  use Tesla
+
+  def get_trips(%Location{} = origin, %Location{} = destination) do
+    case Auth.get_token() do
+      {:error, error} ->
+        {:error, error}
+
+      {:ok, token} ->
+        response =
+          client(token)
+          |> Reseplaneraren.Api.Trip.get_trip(
+            originCoordLat: origin.lat,
+            originCoordLong: origin.long,
+            originCoordName: origin.name,
+            destCoordLat: destination.lat,
+            destCoordLong: destination.long,
+            destCoordName: destination.name,
+            format: "json"
+          )
+          |> parse_results()
+
+        {:ok, response}
+    end
+  end
+
+  defp client(token) do
+    Tesla.build_client([
+      {Tesla.Middleware.Headers,
+       %{"Authorization" => "Bearer " <> token, "Accept" => "application/json"}},
+      Tesla.Middleware.JSON,
+      Tesla.Middleware.DebugLogger
+    ])
+  end
+
+  # for some reason all the api calls returns an error
+  # but the value seems to be parsed properly
+  defp parse_results({:error, %Poison.ParseError{value: json}}), do: json
+end

--- a/lib/restid/api/in_memory.ex
+++ b/lib/restid/api/in_memory.ex
@@ -1,0 +1,521 @@
+defmodule Restid.Api.InMemory do
+  alias Restid.Request.Location
+
+  def get_trips(%Location{} = _origin, %Location{} = _destination) do
+    {:ok,
+     %{
+       "TripList" => %{
+         "Trip" => [
+           %{
+             "Leg" => [
+               %{
+                 "Destination" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "id" => "9022014003610001",
+                   "name" => "Jaegerdorffsplatsen, Göteborg",
+                   "time" => "12:24",
+                   "track" => "A",
+                   "type" => "ST"
+                 },
+                 "Origin" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "name" => "Seglaregatan",
+                   "time" => "12:18",
+                   "type" => "ADR"
+                 },
+                 "name" => "Gå",
+                 "type" => "WALK"
+               },
+               %{
+                 "Destination" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "id" => "9022014001950001",
+                   "name" => "Centralstationen, Göteborg",
+                   "routeIdx" => "13",
+                   "rtDate" => "2020-02-08",
+                   "rtTime" => "12:41",
+                   "time" => "12:39",
+                   "track" => "A",
+                   "type" => "ST"
+                 },
+                 "JourneyDetailRef" => %{
+                   "ref" =>
+                     "https://api.vasttrafik.se/bin/rest.exe/v2/journeyDetail?ref=991194%2F333453%2F334018%2F163395%2F80%3Fdate%3D2020-02-08%26station_evaId%3D3610001%26station_type%3Ddep%26format%3Djson%26"
+                 },
+                 "Origin" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "id" => "9022014003610001",
+                   "name" => "Jaegerdorffsplatsen, Göteborg",
+                   "routeIdx" => "5",
+                   "rtDate" => "2020-02-08",
+                   "rtTime" => "12:26",
+                   "time" => "12:24",
+                   "track" => "A",
+                   "type" => "ST"
+                 },
+                 "accessibility" => "wheelChair",
+                 "bgColor" => "#006C93",
+                 "direction" => "Angered",
+                 "fgColor" => "#D0EDFB",
+                 "id" => "9015014500900049",
+                 "journeyNumber" => "49",
+                 "name" => "Spårvagn 9",
+                 "sname" => "9",
+                 "stroke" => "Solid",
+                 "type" => "TRAM"
+               },
+               %{
+                 "Destination" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "name" => "Centralstationen",
+                   "time" => "12:41",
+                   "type" => "ADR"
+                 },
+                 "Origin" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "id" => "9022014001950001",
+                   "name" => "Centralstationen, Göteborg",
+                   "time" => "12:39",
+                   "track" => "A",
+                   "type" => "ST"
+                 },
+                 "name" => "Gå",
+                 "type" => "WALK"
+               }
+             ]
+           },
+           %{
+             "Leg" => [
+               %{
+                 "Destination" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "id" => "9022014003610001",
+                   "name" => "Jaegerdorffsplatsen, Göteborg",
+                   "time" => "12:34",
+                   "track" => "A",
+                   "type" => "ST"
+                 },
+                 "Origin" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "name" => "Seglaregatan",
+                   "time" => "12:28",
+                   "type" => "ADR"
+                 },
+                 "name" => "Gå",
+                 "type" => "WALK"
+               },
+               %{
+                 "Destination" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "id" => "9022014001950001",
+                   "name" => "Centralstationen, Göteborg",
+                   "routeIdx" => "13",
+                   "rtDate" => "2020-02-08",
+                   "rtTime" => "12:49",
+                   "time" => "12:49",
+                   "track" => "A",
+                   "type" => "ST"
+                 },
+                 "JourneyDetailRef" => %{
+                   "ref" =>
+                     "https://api.vasttrafik.se/bin/rest.exe/v2/journeyDetail?ref=538743%2F182636%2F523100%2F81976%2F80%3Fdate%3D2020-02-08%26station_evaId%3D3610001%26station_type%3Ddep%26format%3Djson%26"
+                 },
+                 "Origin" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "id" => "9022014003610001",
+                   "name" => "Jaegerdorffsplatsen, Göteborg",
+                   "routeIdx" => "5",
+                   "rtDate" => "2020-02-08",
+                   "rtTime" => "12:34",
+                   "time" => "12:34",
+                   "track" => "A",
+                   "type" => "ST"
+                 },
+                 "accessibility" => "wheelChair",
+                 "bgColor" => "#006C93",
+                 "direction" => "Angered",
+                 "fgColor" => "#D0EDFB",
+                 "id" => "9015014500900051",
+                 "journeyNumber" => "51",
+                 "name" => "Spårvagn 9",
+                 "sname" => "9",
+                 "stroke" => "Solid",
+                 "type" => "TRAM"
+               },
+               %{
+                 "Destination" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "name" => "Centralstationen",
+                   "time" => "12:51",
+                   "type" => "ADR"
+                 },
+                 "Origin" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "id" => "9022014001950001",
+                   "name" => "Centralstationen, Göteborg",
+                   "time" => "12:49",
+                   "track" => "A",
+                   "type" => "ST"
+                 },
+                 "name" => "Gå",
+                 "type" => "WALK"
+               }
+             ]
+           },
+           %{
+             "Leg" => [
+               %{
+                 "Destination" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "id" => "9022014004730001",
+                   "name" => "Mariaplan, Göteborg",
+                   "time" => "12:37",
+                   "track" => "A",
+                   "type" => "ST"
+                 },
+                 "Origin" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "name" => "Seglaregatan",
+                   "time" => "12:29",
+                   "type" => "ADR"
+                 },
+                 "name" => "Gå",
+                 "type" => "WALK"
+               },
+               %{
+                 "Destination" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "id" => "9022014001950001",
+                   "name" => "Centralstationen, Göteborg",
+                   "routeIdx" => "23",
+                   "rtDate" => "2020-02-08",
+                   "rtTime" => "12:58",
+                   "time" => "12:59",
+                   "track" => "A",
+                   "type" => "ST"
+                 },
+                 "JourneyDetailRef" => %{
+                   "ref" =>
+                     "https://api.vasttrafik.se/bin/rest.exe/v2/journeyDetail?ref=636777%2F215380%2F152166%2F136184%2F80%3Fdate%3D2020-02-08%26station_evaId%3D4730001%26station_type%3Ddep%26format%3Djson%26"
+                 },
+                 "Origin" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "id" => "9022014004730001",
+                   "name" => "Mariaplan, Göteborg",
+                   "routeIdx" => "11",
+                   "rtDate" => "2020-02-08",
+                   "rtTime" => "12:37",
+                   "time" => "12:38",
+                   "track" => "A",
+                   "type" => "ST"
+                 },
+                 "accessibility" => "wheelChair",
+                 "bgColor" => "#FFFFFF",
+                 "direction" => "Bergsjön",
+                 "fgColor" => "#000000",
+                 "id" => "9015014501100069",
+                 "journeyNumber" => "69",
+                 "name" => "Spårvagn 11",
+                 "sname" => "11",
+                 "stroke" => "Solid",
+                 "type" => "TRAM"
+               },
+               %{
+                 "Destination" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "name" => "Centralstationen",
+                   "time" => "13:00",
+                   "type" => "ADR"
+                 },
+                 "Origin" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "id" => "9022014001950001",
+                   "name" => "Centralstationen, Göteborg",
+                   "time" => "12:58",
+                   "track" => "A",
+                   "type" => "ST"
+                 },
+                 "name" => "Gå",
+                 "type" => "WALK"
+               }
+             ],
+             "alternative" => "true"
+           },
+           %{
+             "Leg" => [
+               %{
+                 "Destination" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "id" => "9022014003610001",
+                   "name" => "Jaegerdorffsplatsen, Göteborg",
+                   "time" => "12:44",
+                   "track" => "A",
+                   "type" => "ST"
+                 },
+                 "Origin" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "name" => "Seglaregatan",
+                   "time" => "12:38",
+                   "type" => "ADR"
+                 },
+                 "name" => "Gå",
+                 "type" => "WALK"
+               },
+               %{
+                 "Destination" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "id" => "9022014001950001",
+                   "name" => "Centralstationen, Göteborg",
+                   "routeIdx" => "13",
+                   "rtDate" => "2020-02-08",
+                   "rtTime" => "12:59",
+                   "time" => "12:59",
+                   "track" => "A",
+                   "type" => "ST"
+                 },
+                 "JourneyDetailRef" => %{
+                   "ref" =>
+                     "https://api.vasttrafik.se/bin/rest.exe/v2/journeyDetail?ref=825816%2F278327%2F629634%2F39553%2F80%3Fdate%3D2020-02-08%26station_evaId%3D3610001%26station_type%3Ddep%26format%3Djson%26"
+                 },
+                 "Origin" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "id" => "9022014003610001",
+                   "name" => "Jaegerdorffsplatsen, Göteborg",
+                   "routeIdx" => "5",
+                   "rtDate" => "2020-02-08",
+                   "rtTime" => "12:44",
+                   "time" => "12:44",
+                   "track" => "A",
+                   "type" => "ST"
+                 },
+                 "accessibility" => "wheelChair",
+                 "bgColor" => "#006C93",
+                 "direction" => "Angered",
+                 "fgColor" => "#D0EDFB",
+                 "id" => "9015014500900053",
+                 "journeyNumber" => "53",
+                 "name" => "Spårvagn 9",
+                 "sname" => "9",
+                 "stroke" => "Solid",
+                 "type" => "TRAM"
+               },
+               %{
+                 "Destination" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "name" => "Centralstationen",
+                   "time" => "13:01",
+                   "type" => "ADR"
+                 },
+                 "Origin" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "id" => "9022014001950001",
+                   "name" => "Centralstationen, Göteborg",
+                   "time" => "12:59",
+                   "track" => "A",
+                   "type" => "ST"
+                 },
+                 "name" => "Gå",
+                 "type" => "WALK"
+               }
+             ]
+           },
+           %{
+             "Leg" => [
+               %{
+                 "Destination" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "id" => "9022014003610001",
+                   "name" => "Jaegerdorffsplatsen, Göteborg",
+                   "time" => "12:54",
+                   "track" => "A",
+                   "type" => "ST"
+                 },
+                 "Origin" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "name" => "Seglaregatan",
+                   "time" => "12:48",
+                   "type" => "ADR"
+                 },
+                 "name" => "Gå",
+                 "type" => "WALK"
+               },
+               %{
+                 "Destination" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "id" => "9022014001950001",
+                   "name" => "Centralstationen, Göteborg",
+                   "routeIdx" => "13",
+                   "rtDate" => "2020-02-08",
+                   "rtTime" => "13:09",
+                   "time" => "13:09",
+                   "track" => "A",
+                   "type" => "ST"
+                 },
+                 "JourneyDetailRef" => %{
+                   "ref" =>
+                     "https://api.vasttrafik.se/bin/rest.exe/v2/journeyDetail?ref=870276%2F293147%2F261926%2F159138%2F80%3Fdate%3D2020-02-08%26station_evaId%3D3610001%26station_type%3Ddep%26format%3Djson%26"
+                 },
+                 "Origin" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "id" => "9022014003610001",
+                   "name" => "Jaegerdorffsplatsen, Göteborg",
+                   "routeIdx" => "5",
+                   "rtDate" => "2020-02-08",
+                   "rtTime" => "12:54",
+                   "time" => "12:54",
+                   "track" => "A",
+                   "type" => "ST"
+                 },
+                 "accessibility" => "wheelChair",
+                 "bgColor" => "#006C93",
+                 "direction" => "Angered",
+                 "fgColor" => "#D0EDFB",
+                 "id" => "9015014500900055",
+                 "journeyNumber" => "55",
+                 "name" => "Spårvagn 9",
+                 "sname" => "9",
+                 "stroke" => "Solid",
+                 "type" => "TRAM"
+               },
+               %{
+                 "Destination" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "name" => "Centralstationen",
+                   "time" => "13:11",
+                   "type" => "ADR"
+                 },
+                 "Origin" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "id" => "9022014001950001",
+                   "name" => "Centralstationen, Göteborg",
+                   "time" => "13:09",
+                   "track" => "A",
+                   "type" => "ST"
+                 },
+                 "name" => "Gå",
+                 "type" => "WALK"
+               }
+             ]
+           },
+           %{
+             "Leg" => [
+               %{
+                 "Destination" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "id" => "9022014003610001",
+                   "name" => "Jaegerdorffsplatsen, Göteborg",
+                   "time" => "13:04",
+                   "track" => "A",
+                   "type" => "ST"
+                 },
+                 "Origin" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "name" => "Seglaregatan",
+                   "time" => "12:58",
+                   "type" => "ADR"
+                 },
+                 "name" => "Gå",
+                 "type" => "WALK"
+               },
+               %{
+                 "Destination" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "id" => "9022014001950001",
+                   "name" => "Centralstationen, Göteborg",
+                   "routeIdx" => "13",
+                   "rtDate" => "2020-02-08",
+                   "rtTime" => "13:19",
+                   "time" => "13:19",
+                   "track" => "A",
+                   "type" => "ST"
+                 },
+                 "JourneyDetailRef" => %{
+                   "ref" =>
+                     "https://api.vasttrafik.se/bin/rest.exe/v2/journeyDetail?ref=442416%2F150527%2F597264%2F151170%2F80%3Fdate%3D2020-02-08%26station_evaId%3D3610001%26station_type%3Ddep%26format%3Djson%26"
+                 },
+                 "Origin" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "id" => "9022014003610001",
+                   "name" => "Jaegerdorffsplatsen, Göteborg",
+                   "routeIdx" => "5",
+                   "rtDate" => "2020-02-08",
+                   "rtTime" => "13:04",
+                   "time" => "13:04",
+                   "track" => "A",
+                   "type" => "ST"
+                 },
+                 "accessibility" => "wheelChair",
+                 "bgColor" => "#006C93",
+                 "direction" => "Angered",
+                 "fgColor" => "#D0EDFB",
+                 "id" => "9015014500900057",
+                 "journeyNumber" => "57",
+                 "name" => "Spårvagn 9",
+                 "sname" => "9",
+                 "stroke" => "Solid",
+                 "type" => "TRAM"
+               },
+               %{
+                 "Destination" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "name" => "Centralstationen",
+                   "time" => "13:21",
+                   "type" => "ADR"
+                 },
+                 "Origin" => %{
+                   "$" => "\n",
+                   "date" => "2020-02-08",
+                   "id" => "9022014001950001",
+                   "name" => "Centralstationen, Göteborg",
+                   "time" => "13:19",
+                   "track" => "A",
+                   "type" => "ST"
+                 },
+                 "name" => "Gå",
+                 "type" => "WALK"
+               }
+             ]
+           }
+         ],
+         "noNamespaceSchemaLocation" => "http://api.vasttrafik.se/v1/hafasRestTrip.xsd",
+         "serverdate" => "2020-02-08",
+         "servertime" => "12:16"
+       }
+     }}
+  end
+end

--- a/lib/restid/request/location.ex
+++ b/lib/restid/request/location.ex
@@ -1,4 +1,4 @@
-defmodule Restid.Model.Location do
+defmodule Restid.Request.Location do
   @enforce_keys [:name, :long, :lat]
   defstruct [:name, :long, :lat]
 end

--- a/lib/restid/response.ex
+++ b/lib/restid/response.ex
@@ -1,6 +1,10 @@
 defmodule Restid.Response do
   defstruct [:server_date_time, :trips]
 
+  def parse_result({:ok, json}) do
+    parse_from_json(json)
+  end
+
   def parse_from_json(json) do
     server_date_time =
       NaiveDateTime.from_iso8601!(

--- a/lib/restid/response.ex
+++ b/lib/restid/response.ex
@@ -1,0 +1,19 @@
+defmodule Restid.Response do
+  defstruct [:server_date_time, :trips]
+
+  def parse_from_json(json) do
+    server_date_time =
+      NaiveDateTime.from_iso8601!(
+        "#{json["TripList"]["serverdate"]} #{json["TripList"]["servertime"]}:00"
+      )
+
+    %Restid.Response{
+      server_date_time: server_date_time,
+      trips:
+        Enum.map(
+          json["TripList"]["Trip"],
+          &Restid.Response.Trip.parse_from_json(&1, server_date_time)
+        )
+    }
+  end
+end

--- a/lib/restid/response/leg.ex
+++ b/lib/restid/response/leg.ex
@@ -1,0 +1,44 @@
+defmodule Restid.Response.Leg do
+  defstruct [
+    :id,
+    :name,
+    :short_name,
+    :type,
+    :origin,
+    :destination,
+    :expected_departure_date_time,
+    :expected_arrival_date_time
+  ]
+
+  def parse_from_json(json) do
+    origin = Restid.Response.Stop.parse_from_json(json["Origin"])
+    destination = Restid.Response.Stop.parse_from_json(json["Destination"])
+
+    %Restid.Response.Leg{
+      id: json["id"],
+      name: json["name"],
+      short_name: json["sname"],
+      type: parse_type(json["type"]),
+      origin: origin,
+      destination: destination,
+      expected_departure_date_time: get_time_from_stop(origin),
+      expected_arrival_date_time: get_time_from_stop(destination)
+    }
+  end
+
+  defp parse_type(type_string) do
+    case type_string do
+      "WALK" -> :walk
+      "TRAM" -> :tram
+      "BUS" -> :bus
+    end
+  end
+
+  defp get_time_from_stop(stop) do
+    cond do
+      stop.real_time_date_time -> {:real_time, stop.real_time_date_time}
+      stop.scheduled_date_time -> {:scheduled, stop.scheduled_date_time}
+      true -> :unknown
+    end
+  end
+end

--- a/lib/restid/response/stop.ex
+++ b/lib/restid/response/stop.ex
@@ -1,0 +1,29 @@
+defmodule Restid.Response.Stop do
+  defstruct [:id, :name, :type, :short_name, :real_time_date_time, :scheduled_date_time]
+
+  def parse_from_json(json) do
+    %Restid.Response.Stop{
+      id: json["id"],
+      name: json["name"],
+      short_name: json["name"],
+      type: parse_type(json["type"]),
+      real_time_date_time: parse_date_time(json["rtDate"], json["rtTime"]),
+      scheduled_date_time: parse_date_time(json["date"], json["time"])
+    }
+  end
+
+  defp parse_type(type_string) do
+    case type_string do
+      "ST" -> :stop
+      "ADR" -> :address
+      _ -> :unknown
+    end
+  end
+
+  defp parse_date_time(date_string, time_string) do
+    case NaiveDateTime.from_iso8601("#{date_string} #{time_string}:00") do
+      {:ok, date_time} -> date_time
+      _ -> nil
+    end
+  end
+end

--- a/lib/restid/response/trip.ex
+++ b/lib/restid/response/trip.ex
@@ -1,0 +1,38 @@
+defmodule Restid.Response.Trip do
+  defstruct [
+    :current_server_date_time,
+    :expected_departure_date_time,
+    :expected_arrival_date_time,
+    :legs
+  ]
+
+  def parse_from_json(json, server_date_time) do
+    legs =
+      json["Leg"]
+      |> Enum.map(&Restid.Response.Leg.parse_from_json(&1))
+      |> trim_leading_walk_directions()
+      |> trim_trailing_walk_directions()
+
+    expected_departure_date_time = List.first(legs).expected_departure_date_time
+    expected_arrival_date_time = List.last(legs).expected_arrival_date_time
+
+    %Restid.Response.Trip{
+      legs: legs,
+      current_server_date_time: server_date_time,
+      expected_departure_date_time: expected_departure_date_time,
+      expected_arrival_date_time: expected_arrival_date_time
+    }
+  end
+
+  defp trim_leading_walk_directions(legs) do
+    legs
+    |> Enum.drop_while(fn l -> l.type === :walk end)
+  end
+
+  defp trim_trailing_walk_directions(legs) do
+    legs
+    |> Enum.reverse()
+    |> Enum.drop_while(fn l -> l.type === :walk end)
+    |> Enum.reverse()
+  end
+end

--- a/lib/restid/utils/locations.ex
+++ b/lib/restid/utils/locations.ex
@@ -1,5 +1,5 @@
 defmodule Restid.Utils.Locations do
-  alias Restid.Model.Location
+  alias Restid.Request.Location
 
   def seglaregatan do
     %Location{name: "Seglaregatan", lat: 57.690368, long: 11.919743}

--- a/lib/sensors/supervisor.ex
+++ b/lib/sensors/supervisor.ex
@@ -13,10 +13,10 @@ defmodule Restid.Sensor.Supervisor do
 
   def init(:ok) do
     trips_config = %{
-      origin: struct(Restid.Model.Location, Application.get_env(:restid, :origin)),
+      origin: struct(Restid.Request.Location, Application.get_env(:restid, :origin)),
       destinations:
         Application.get_env(:restid, :destinations)
-        |> Enum.map(&struct(Restid.Model.Location, &1))
+        |> Enum.map(&struct(Restid.Request.Location, &1))
     }
 
     children = [

--- a/lib/sensors/trips.ex
+++ b/lib/sensors/trips.ex
@@ -31,14 +31,10 @@ defmodule Restid.Sensor.Trips do
       state.destinations
       |> Enum.map(&Restid.get_trips(state.origin, &1))
       |> Enum.filter(&match?({:ok, _}, &1))
-      |> Enum.map(fn {:ok, trips} -> trips end)
-      |> Enum.flat_map(&get_in(&1, ["TripList", "Trip"]))
+      |> Enum.map(fn {:ok, response} -> response end)
+      |> Enum.flat_map(fn r -> r.trips end)
 
     Sensor.publish(:trips, trips)
-
-    trips
-    |> Enum.map(&Restid.Utils.Trips.to_string/1)
-    |> Enum.map(&IO.puts/1)
 
     Process.send_after(self(), :poll, @poll_interval)
 

--- a/mix.exs
+++ b/mix.exs
@@ -13,10 +13,16 @@ defmodule Restid.MixProject do
       archives: [nerves_bootstrap: "~> 1.7"],
       build_embedded: true,
       start_permanent: Mix.env() == :prod,
-      aliases: [loadconfig: [&bootstrap/1]],
+      aliases: [loadconfig: [&bootstrap/1]] ++ aliases(),
       deps: deps(),
       releases: [{@app, release()}],
       preferred_cli_target: [run: :host, test: :host]
+    ]
+  end
+
+  defp aliases do
+    [
+      test: "test --no-start"
     ]
   end
 

--- a/test/auth_test.exs
+++ b/test/auth_test.exs
@@ -2,10 +2,10 @@ defmodule AuthTest do
   use ExUnit.Case
   doctest Auth
 
-  # setup do
-  #   auth = start_supervised!(Auth)
-  #   %{auth: auth}
-  # end
+  setup do
+    auth = start_supervised!(Auth)
+    %{auth: auth}
+  end
 
   test "token not expired" do
     valid_token = %Auth.Model.Token{

--- a/test/restid_test.exs
+++ b/test/restid_test.exs
@@ -1,6 +1,6 @@
 defmodule RestidTest do
   use ExUnit.Case
-  # doctest Restid
+  doctest Restid
 
   # test "greets the world" do
   #  assert Restid.hello() == :world

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,7 @@
+Application.load(:restid)
+
+for app <- Application.spec(:restid, :applications) do
+  Application.ensure_all_started(app)
+end
+
 ExUnit.start()


### PR DESCRIPTION
# What does this PR do?

Refactor the Restid API to return a new struct `%Restid.Response{}`.

# Why was this PR needed?

The return value from the Reseplaneraren api is not very elixir friendly and this new type gives us some nice struct types to work with.
